### PR TITLE
1368 Hjelpetekst til skjermleser for å informere om hva knappen gjør

### DIFF
--- a/src/components/fyll-ut/steg-2-fravær/dag/FraværDagPanel.tsx
+++ b/src/components/fyll-ut/steg-2-fravær/dag/FraværDagPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { TekstSegmenter } from '@components/tekst/TekstSegmenter.tsx';
 
 import style from './FraværDagPanel.module.css';
+import { getTekst } from '@tekster/tekster.ts';
 
 type Props = {
     dag: MeldekortDag;
@@ -42,6 +43,10 @@ export const FraværDagPanel = ({ dag }: Props) => {
                     setValgtMeldekortDag(dag);
                 }}
                 className={style.knapp}
+                aria-label={getTekst({
+                    id: 'fraværPanelRegistrerSR',
+                    resolverProps: { datoTekst },
+                })}
             >
                 <Tekst id={'fraværPanelRegistrer'} />
             </Button>

--- a/src/tekster/nb.ts
+++ b/src/tekster/nb.ts
@@ -110,7 +110,8 @@ export const teksterNb = {
     fraværUkeHjelp: 'Velg hva slags fravær du hadde',
 
     fraværPanelRegistrer: 'Velg',
-
+    fraværPanelRegistrerSR: ({ datoTekst }: { datoTekst: string }) =>
+        `${datoTekst} - Velg årsak til fravær`,
     fraværModalHeader: 'Årsaken til fraværet',
     fraværModalBeskrivelse: 'Du kan ha rett til tiltakspenger selv om du ikke har deltatt',
     fraværModalSykIngress: 'Hvis du var for syk til å delta på tiltaksdagen.',

--- a/tests/meldekort-steg.test.ts
+++ b/tests/meldekort-steg.test.ts
@@ -133,8 +133,9 @@ const fyllUtDeltattSteg = async (page: Page, fravær: boolean, antallDeltatt: nu
 
 const fyllUtFraværSteg = async (page: Page, antallDeltatt: number, antallFravær: number) => {
     const velgFraværKnapper = page.getByRole('button', {
-        name: getTekst({ id: 'fraværPanelRegistrer' }),
-        exact: true,
+        // datoTekst varierer for hver dagså vi matcher på alt utenom den.
+        name: getTekst({ id: 'fraværPanelRegistrerSR', resolverProps: { datoTekst: '' } }),
+        exact: false,
     });
     const sykRadio = page.getByRole('radio', {
         name: getTekst({ id: 'fraværModalSykIngress' }),
@@ -148,6 +149,7 @@ const fyllUtFraværSteg = async (page: Page, antallDeltatt: number, antallFravæ
     await fyllUtDeltattSteg(page, true, antallDeltatt);
 
     for (let i = 0; i < antallFravær; ++i) {
+        await expect(velgFraværKnapper.nth(i)).toHaveText(getTekst({ id: 'fraværPanelRegistrer' }));
         await velgFraværKnapper.nth(i).click();
         await expect(fraværModal).toBeVisible();
         await sykRadio.click();


### PR DESCRIPTION
Når man har valgt årsak til fravær inne i modalen så vil en skjermleser fortsatt ha "Velg" som aktivt valgt for hva skjermleseren leser opp. Dermed er det vanskelig å vite hvor man er på siden