### PR TITLE
1330 viser ikke søknad under behandling hvis neste meldekort ikke er …

### DIFF
--- a/src/components/forside/ikke-klar-til-utfylling/IkkeKlarTilUtfylling.tsx
+++ b/src/components/forside/ikke-klar-til-utfylling/IkkeKlarTilUtfylling.tsx
@@ -15,12 +15,12 @@ export const IkkeKlarTilUtfylling = ({ meldekortBruker }: Props) => {
 
     return (
         <Alert variant={'info'} contentMaxWidth={false} className={style.wrapper}>
-            {harSoknadUnderBehandling && (
+            {harSoknadUnderBehandling && !nesteMeldekort && (
                 <BodyLong>
                     <Tekst id={'forsideIngenMeldekortSoknadUnderBehandling'} />
                 </BodyLong>
             )}
-            {!harSoknadUnderBehandling && (
+            {(!harSoknadUnderBehandling || nesteMeldekort) && (
                 <BodyLong>
                     <Tekst id={'forsideIngenMeldekort'} />
                     {nesteMeldekort?.status === MeldekortStatus.IKKE_KLAR &&


### PR DESCRIPTION
…klart ennå

https://trello.com/c/jgqwF8EI/1330-brukervennlig-beskjed-n%C3%A5r-bruker-ikke-har-noen-meldekort-%C3%A5-fylle-ut-fordi-s%C3%B8knaden-deres-ikke-enda-er-ferdig-behandlet