### PR TITLE
1881 legger til engelsk der det manglet oversettelse

### DIFF
--- a/src/components/forside/ForsideBrukerMedSak.tsx
+++ b/src/components/forside/ForsideBrukerMedSak.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export const ForsideBrukerMedSak = ({ meldekortBruker }: Props) => {
     const { nesteMeldekort } = meldekortBruker;
-    const { getTekstForSpråk } = useSpråk();
+    const { getTekstForSpråk, valgtSpråk } = useSpråk();
 
     return (
         <>
@@ -35,7 +35,11 @@ export const ForsideBrukerMedSak = ({ meldekortBruker }: Props) => {
             ) : (
                 <IkkeKlarTilUtfylling meldekortBruker={meldekortBruker} />
             )}
-            <InternLenke path={getPath(siteRoutePaths.innsendte)} className={style.tidligere}>
+            <InternLenke
+                path={getPath(siteRoutePaths.innsendte)}
+                locale={valgtSpråk}
+                className={style.tidligere}
+            >
                 <Tekst id={'forsideSeOgEndre'} />
             </InternLenke>
         </>

--- a/src/components/fyll-ut/steg-3-deltakelse/Steg3_Deltakelse.tsx
+++ b/src/components/fyll-ut/steg-3-deltakelse/Steg3_Deltakelse.tsx
@@ -13,6 +13,7 @@ import { MeldekortStegButtons } from '@components/fyll-ut/MeldekortStegButtons.t
 import { useInitMeldekortSteg } from '@components/fyll-ut/useInitMeldekortSteg.tsx';
 import { Meldekort } from '@common/typer/MeldekortBruker';
 import { InternLenke } from '@components/lenke/InternLenke';
+import { useSpråk } from '@context/språk/useSpråk.ts';
 
 type SSRProps = {
     brukersMeldekort: Meldekort;
@@ -36,10 +37,11 @@ export const Steg3_Deltakelse = ({ brukersMeldekort, kanFylleUtHelg }: SSRProps)
 };
 
 const MeldekortEksistererIkke = () => {
+    const { valgtSpråk } = useSpråk();
     return (
         <div>
             <Alert variant={'error'}>
-                <InternLenke path={getPath(siteRoutePaths.forside)}>
+                <InternLenke path={getPath(siteRoutePaths.forside)} locale={valgtSpråk}>
                     En feil har skjedd. Tilbake til forsiden
                 </InternLenke>
             </Alert>

--- a/src/components/fyll-ut/steg-5-kvittering/Steg5_Kvittering.tsx
+++ b/src/components/fyll-ut/steg-5-kvittering/Steg5_Kvittering.tsx
@@ -9,6 +9,7 @@ import { MeldekortStegWrapper } from '@components/fyll-ut/MeldekortStegWrapper.t
 import { getPath, siteRoutePaths } from '@common/siteRoutePaths.ts';
 import { Meldekort, MeldekortStatus } from '@common/typer/MeldekortBruker';
 import useScript from '@components/fyll-ut/steg-5-kvittering/useScript.tsx';
+import { useSpråk } from '@context/språk/useSpråk.ts';
 
 type SSRProps = {
     brukersMeldekort: Meldekort;
@@ -18,6 +19,7 @@ export const Steg5_Kvittering = ({ brukersMeldekort }: SSRProps) => {
     useScript(true); // UX Signals script for brukertesting
     const { meldekortUtfylling, setMeldekortUtfylling, redirectHvisMeldekortErInnsendt } =
         useMeldekortUtfylling();
+    const { valgtSpråk } = useSpråk();
 
     useEffect(() => {
         redirectHvisMeldekortErInnsendt(brukersMeldekort, meldekortUtfylling, 'kvittering');
@@ -41,7 +43,7 @@ export const Steg5_Kvittering = ({ brukersMeldekort }: SSRProps) => {
                     <Alert variant={'success'} className={style.kvittering}>
                         <TekstSegmenter id={'kvittering'} spacing={true} />
                     </Alert>
-                    <InternLenke path={getPath(siteRoutePaths.forside)}>
+                    <InternLenke path={getPath(siteRoutePaths.forside)} locale={valgtSpråk}>
                         <Tekst id={'kvitteringTilbake'} />
                     </InternLenke>
                 </div>

--- a/src/components/innsendte/InnsendteMeldekort.tsx
+++ b/src/components/innsendte/InnsendteMeldekort.tsx
@@ -52,7 +52,7 @@ export const InnsendteMeldekort = ({
                         <Tekst id={'ingenInnsendteMeldekort'} />
                     )}
                 </Heading>
-                <InternLenke path={getPath(siteRoutePaths.forside)}>
+                <InternLenke path={getPath(siteRoutePaths.forside)} locale={valgtSpråk}>
                     <Tekst id={'innsendteTilbake'} />
                 </InternLenke>
             </div>
@@ -91,6 +91,7 @@ export const InnsendteMeldekort = ({
                                             //slipper å ha / i url'en mellom periodene.
                                             kjedeId: sisteMeldekort.kjedeId.replaceAll('/', '_'),
                                         })}
+                                        locale={valgtSpråk}
                                     >
                                         <Tekst id={'tidligereMeldekortForPeriode'} />
                                     </InternLenke>

--- a/src/components/innsendte/siste-innsendte/SisteInnsendteMeldekort.tsx
+++ b/src/components/innsendte/siste-innsendte/SisteInnsendteMeldekort.tsx
@@ -37,6 +37,7 @@ export const SisteInnsendteMeldekort = ({ meldekort, visHelg }: Props) => {
                         path={getPath(siteRoutePaths.korrigerMeldekortUtfylling, {
                             meldekortId: meldekort.id,
                         })}
+                        locale={valgtSpråk}
                         className={style.knapp}
                     >
                         <Tekst id={'endreMeldekort'} />

--- a/src/components/innsendteMeldekortForKjede/InnsendteMeldekortForKjede.tsx
+++ b/src/components/innsendteMeldekortForKjede/InnsendteMeldekortForKjede.tsx
@@ -39,7 +39,7 @@ const InnsendteMeldekortForKjede = (props: {
                             />
                         )}
 
-                        <InternLenke path={getPath(siteRoutePaths.innsendte)}>
+                        <InternLenke path={getPath(siteRoutePaths.innsendte)} locale={valgtSpråk}>
                             <Tekst id={'sideForInnsendteMeldekort'} />
                         </InternLenke>
                     </VStack>
@@ -49,7 +49,7 @@ const InnsendteMeldekortForKjede = (props: {
                 {props.meldekortForKjede.meldekort.length === 0 ? (
                     <VStack gap="space-8">
                         <Tekst id={'ingenInnsendteMeldekortForPerioden'} />
-                        <InternLenke path={getPath(siteRoutePaths.innsendte)}>
+                        <InternLenke path={getPath(siteRoutePaths.innsendte)} locale={valgtSpråk}>
                             <Tekst id={'tilbakeTilInnsendte'} />
                         </InternLenke>
                     </VStack>

--- a/src/components/kalender/Kalender.tsx
+++ b/src/components/kalender/Kalender.tsx
@@ -9,6 +9,7 @@ import { getUkenummer, lokalTid } from '@utils/datetime.ts';
 
 import { useSpråk } from '@context/språk/useSpråk.ts';
 import { Meldekort } from '@common/typer/MeldekortBruker.ts';
+import { Tekst } from '@components/tekst/Tekst.tsx';
 
 type Props = {
     meldekort: Meldekort;
@@ -39,9 +40,7 @@ export const Kalender = ({ steg, meldekort, kanFylleUtHelg, className }: Props) 
         <>
             {kanVæreJuleferie() && (
                 <Alert variant="info">
-                    {
-                        'Dersom tiltaket ditt er stengt på grunn av juleferie skal du melde «deltok» på dagene du skulle vært i tiltak. 🎄🎅🤶'
-                    }
+                    <Tekst id={'juleferieInfo'} />
                 </Alert>
             )}
             <div className={classNames(style.kalender, className)}>

--- a/src/components/korrigerMeldekort/KorrigerMeldekortKvittering.tsx
+++ b/src/components/korrigerMeldekort/KorrigerMeldekortKvittering.tsx
@@ -8,9 +8,10 @@ import { Alert, HStack, VStack } from '@navikt/ds-react';
 import { formatterDato } from '@utils/datetime';
 
 import { useSpråk } from '@context/språk/useSpråk.ts';
+import React from 'react';
 
 const KorrigerMeldekortKvittering = (props: { originaleMeldekort: Meldekort }) => {
-    const { valgtSpråk } = useSpråk();
+    const { valgtSpråk, getTekstForSpråk } = useSpråk();
     return (
         <div>
             <PageHeader
@@ -18,11 +19,31 @@ const KorrigerMeldekortKvittering = (props: { originaleMeldekort: Meldekort }) =
                 underTekst={
                     <HStack gap="space-16">
                         <Undertekst
-                            tekst={`Uke ${props.originaleMeldekort.uke1} og ${props.originaleMeldekort.uke2}`}
+                            tekst={getTekstForSpråk({
+                                id: 'undertekstUker',
+                                resolverProps: {
+                                    uke1: props.originaleMeldekort.uke1,
+                                    uke2: props.originaleMeldekort.uke2,
+                                },
+                            })}
                             weight={'semibold'}
                         />
                         <Undertekst
-                            tekst={`(${formatterDato({ dato: props.originaleMeldekort.fraOgMed, locale: valgtSpråk })} til ${formatterDato({ dato: props.originaleMeldekort.tilOgMed, locale: valgtSpråk })})`}
+                            tekst={`(${getTekstForSpråk({
+                                id: 'undertekstDatoer',
+                                resolverProps: {
+                                    fraOgMed: formatterDato({
+                                        dato: props.originaleMeldekort.fraOgMed,
+                                        medUkeDag: false,
+                                        locale: valgtSpråk,
+                                    }),
+                                    tilOgMed: formatterDato({
+                                        dato: props.originaleMeldekort.tilOgMed,
+                                        medUkeDag: false,
+                                        locale: valgtSpråk,
+                                    }),
+                                },
+                            })})`}
                         />
                     </HStack>
                 }
@@ -31,7 +52,7 @@ const KorrigerMeldekortKvittering = (props: { originaleMeldekort: Meldekort }) =
                 <Alert variant="success">
                     <Tekst id={'korrigeringKvittering'} />
                 </Alert>
-                <InternLenke path={getPath(siteRoutePaths.forside)}>
+                <InternLenke path={getPath(siteRoutePaths.forside)} locale={valgtSpråk}>
                     <Tekst id={'kvitteringTilbake'} />
                 </InternLenke>
             </VStack>

--- a/src/components/korrigerMeldekort/send-inn/KorrigerMeldekortSendInn.tsx
+++ b/src/components/korrigerMeldekort/send-inn/KorrigerMeldekortSendInn.tsx
@@ -16,7 +16,7 @@ import { useRouting } from '@routing/useRouting.ts';
 import { getPath, siteRoutePaths } from '@common/siteRoutePaths.ts';
 import { useKorrigerMeldekortContext } from '@context/korriger/KorrigerMeldekortContext.tsx';
 import { Link } from 'wouter';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FlashingButton } from '@components/flashing-button/FlashingButton.tsx';
 import { Tekst } from '@components/tekst/Tekst.tsx';
 import { Meldekort } from '@common/typer/MeldekortBruker.ts';
@@ -53,11 +53,31 @@ export const KorrigerMeldekortSendInn = ({
                 underTekst={
                     <HStack gap="space-16">
                         <Undertekst
-                            tekst={`Uke ${originaleMeldekort.uke1} og ${originaleMeldekort.uke2}`}
+                            tekst={getTekstForSpråk({
+                                id: 'undertekstUker',
+                                resolverProps: {
+                                    uke1: originaleMeldekort.uke1,
+                                    uke2: originaleMeldekort.uke2,
+                                },
+                            })}
                             weight={'semibold'}
                         />
                         <Undertekst
-                            tekst={`(${formatterDato({ dato: originaleMeldekort.fraOgMed, locale: valgtSpråk })} til ${formatterDato({ dato: originaleMeldekort.tilOgMed, locale: valgtSpråk })})`}
+                            tekst={`(${getTekstForSpråk({
+                                id: 'undertekstDatoer',
+                                resolverProps: {
+                                    fraOgMed: formatterDato({
+                                        dato: originaleMeldekort.fraOgMed,
+                                        medUkeDag: false,
+                                        locale: valgtSpråk,
+                                    }),
+                                    tilOgMed: formatterDato({
+                                        dato: originaleMeldekort.tilOgMed,
+                                        medUkeDag: false,
+                                        locale: valgtSpråk,
+                                    }),
+                                },
+                            })})`}
                         />
                     </HStack>
                 }

--- a/src/components/lenke/InternLenke.tsx
+++ b/src/components/lenke/InternLenke.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { Link as RouterLink } from 'wouter';
 import { Link } from '@navikt/ds-react';
+import { TeksterLocale } from '@common/locale.ts';
+import { addLocaleSuffix } from '@common/urls.ts';
 
 type Props = {
     children: React.ReactNode;
     path: string;
+    locale: TeksterLocale;
 } & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
 
-export const InternLenke = ({ children, path }: Props) => {
+export const InternLenke = ({ children, path, locale }: Props) => {
     return (
-        <Link as={RouterLink} href={path}>
+        <Link as={RouterLink} href={addLocaleSuffix(path, locale)}>
             {children}
         </Link>
     );

--- a/src/components/lenke/TekstMedLenke.tsx
+++ b/src/components/lenke/TekstMedLenke.tsx
@@ -15,12 +15,14 @@ type Props = {
 };
 
 export const TekstMedLenke = ({ tekst, tekstLenke, lenke, lenkeType }: Props) => {
-    const { getTekstForSpråk } = useSpråk();
+    const { getTekstForSpråk, valgtSpråk } = useSpråk();
     return (
         <div className={style.wrapper}>
             <Tekst id={tekst} />
             {lenkeType === 'intern' ? (
-                <InternLenke path={lenke}>{getTekstForSpråk({ id: tekstLenke })}</InternLenke>
+                <InternLenke path={lenke} locale={valgtSpråk}>
+                    {getTekstForSpråk({ id: tekstLenke })}
+                </InternLenke>
             ) : (
                 <EksternLenke href={lenke}>{getTekstForSpråk({ id: tekstLenke })}</EksternLenke>
             )}

--- a/src/tekster/en.ts
+++ b/src/tekster/en.ts
@@ -7,7 +7,6 @@ export const teksterEn = {
     startUtfylling: 'Start filling out',
     forrige: 'Previous step',
     lagre: 'Save',
-    slett: 'Slett',
     nullstill: 'Reset',
     avbryt: 'Cancel',
     avbrytEndring: 'Cancel changes',
@@ -51,16 +50,17 @@ export const teksterEn = {
     forsideBekrefterFeil: 'You must confirm to proceed',
     forsideSeOgEndre: 'See previous employment status form(s).',
     forsideIngenMeldekortSoknadUnderBehandling:
-        'Du har ikke fått noen meldekort enda fordi Nav ikke er ferdig med å behandle søknaden din. ',
-    forsideIngenMeldekort: 'Du har ingen meldekort klare til innsending. ',
-    forsideNesteMeldekort1: 'Ditt neste meldekort kan sendes inn fra ',
-    forsideNesteMeldekort2: ' for perioden ',
-    forsideForrigeMeldekort1: 'Din forrige innsending var ',
-    forsideForrigeMeldekort2: ' for perioden ',
+        'You have not received any employment status forms yet because Nav has not finished processing your application. ',
+    forsideIngenMeldekort: 'You have no employment status forms ready for submission. ',
+    forsideNesteMeldekort1: 'Your next employment status form can be submitted from ',
+    forsideNesteMeldekort2: ' for the period ',
+    forsideForrigeMeldekort1: 'Your previous submission was ',
+    forsideForrigeMeldekort2: ' for the period ',
     forsideIkkeTiltakspenger:
-        'Fant ingen meldekort for tiltakspenger. Dersom du tidligere har mottatt tiltakspenger, finner du meldekortene dine i ',
-    forsideHarArenaMeldekort: 'Du kan finne meldekortene dine for tiltakspenger i ',
-    forsideArenaLenke: 'den gamle løsningen for meldekort.',
+        'No employment status forms found. If you received employment scheme benefits for periods earlier than the ones shown here, you can find those employment status forms in ',
+    forsideHarArenaMeldekort:
+        'You can find your employment status forms for employment scheme benefits in ',
+    forsideArenaLenke: 'the previous (old) solution.',
 
     ukeMedNummer: ({ dato }: { dato: string }) => `Week ${getUkenummer(dato, 'en')}`,
     undertekstUker: ({ uke1, uke2 }: { uke1: number; uke2: number }) => `Week ${uke1} and ${uke2}`,
@@ -68,13 +68,10 @@ export const teksterEn = {
         `${fraOgMed} to ${tilOgMed}`,
 
     deltattTittel: 'Attendance',
-    deltattHjelpTittel: 'Slik fyller du ut meldekortet',
     deltattHjelpIngress:
         'Please select the days you participated in activities as agreed. You should select “participated” if the day was a public holiday and you did not participate because the employment scheme was closed.',
     deltattUkeHjelp: 'Please select the days you participated in activities.',
     deltattDagPrefix: 'Participated: ',
-    fraværHjelpLesMer:
-        'Du må informere oss dersom du har vært syk eller hatt annet fravær i perioden du var satt opp på tiltak.',
     fraværStegFraværSpørsmål:
         'Have you been sick or absent for other reasons on any of the days you were supposed to participate in employment scheme activities?',
     fraværHarHattFraværSvarJa: 'Yes, I have been sick or absent for other reasons',
@@ -182,15 +179,15 @@ export const teksterEn = {
             'If some of the information you provided means we need additional documentation, it may take a little longer before you receive payment.',
     ],
 
-    tilbakeTilOversiktForNyKorrigering: 'Gå tilbake til oversikten for å starte en ny korrigering',
+    tilbakeTilOversiktForNyKorrigering: 'Return to the overview to start a new edit',
 
     // Innsendte
-    innsendteTittel: 'Innsendte meldekort',
-    innsendteHeading: 'Her er alle innsendte meldekortene dine',
-    ingenInnsendteMeldekort: 'Du har ingen innsendte meldekort',
-    innsendteTilbake: 'Tilbake til startsiden for meldekort',
-    alleInnsendt: ({ dato }: { dato: string }) => `Innsendt ${dato}`,
-    ikkeInnsendt: 'Ikke innsendt',
+    innsendteTittel: 'Submitted employment status forms',
+    innsendteHeading: 'Here are all your submitted employment status forms',
+    ingenInnsendteMeldekort: 'You have no submitted employment status forms',
+    innsendteTilbake: 'Back to the employment status form homepage',
+    alleInnsendt: ({ dato }: { dato: string }) => `Submitted ${dato}`,
+    ikkeInnsendt: 'Not submitted',
     innsendtMeldekortAccordionHeader: ({
         uke1,
         uke2,
@@ -201,25 +198,26 @@ export const teksterEn = {
         uke2: number;
         fraOgMed: string;
         tilOgMed: string;
-    }) => `Meldekort uke ${uke1} - ${uke2} (${fraOgMed} - ${tilOgMed})`,
-    endreMeldekort: 'Edit employment status form ',
+    }) => `Employment status form week ${uke1} - ${uke2} (${fraOgMed} - ${tilOgMed})`,
+    endreMeldekort: 'Edit employment status form',
     tidligereMeldekortForPeriode:
-        'Se tidligere meldekort som har blitt sendt inn for samme perioden',
+        'See previous employment status forms that have been submitted for the same period',
 
     //InnsendteMeldekortForKjede
     meldekortForKjedeHeaderUndertekst: (args: { periode: Periode }) =>
-        `Her ser du innsendte meldekort for perioden ${formatterDato({ dato: args.periode.fraOgMed, locale: 'en' })} - ${formatterDato({ dato: args.periode.tilOgMed, locale: 'en' })}.`,
-    ingenInnsendteMeldekortForPerioden: 'Ingen innsendte meldekort for denne perioden.',
-    sisteInnsendteMeldekortForPerioden: 'Siste innsendte meldekort for perioden',
-    tidligereInnsendteMeldekortForPerioden: 'Tidligere innsendte meldekort for perioden',
-    sideForInnsendteMeldekort: 'Tilbake til side for innsendte meldekort',
-    tilbakeTilInnsendte: 'Tilbake til innsendte meldekort',
+        `Here you can see submitted employment status forms for the period ${formatterDato({ dato: args.periode.fraOgMed, locale: 'en' })} - ${formatterDato({ dato: args.periode.tilOgMed, locale: 'en' })}.`,
+    ingenInnsendteMeldekortForPerioden: 'No submitted employment status forms for this period.',
+    sisteInnsendteMeldekortForPerioden: 'Last submitted employment status form for the period',
+    tidligereInnsendteMeldekortForPerioden:
+        'Previously submitted employment status forms for the period',
+    sideForInnsendteMeldekort: 'Return to submitted employment status forms page',
+    tilbakeTilInnsendte: 'Return to submitted employment status forms',
 
     //Arena
     alleUkjentArenaMeldekort:
-        'Dersom du fikk tiltakspenger i perioder før de som vises her, finner du meldekortene i den ',
-    alleHarArenaMeldekort: 'Meldekort fra tidligere perioder finner du i den ',
-    alleArenaLenke: 'gamle løsningen for meldekort',
+        'If you received employment scheme benefits for periods earlier than the ones shown here, you can find those employment status forms in ',
+    alleHarArenaMeldekort: 'Employment status forms for previous periods can be found in ',
+    alleArenaLenke: 'the previous (old) solution',
     korrigeringLønnHeader: 'When do I select "received pay"?',
     korrigeringLønnBeskrivelse:
         'If you receive pay (not employment scheme benefits) as part of your programme, choose "Received pay".',
@@ -247,6 +245,9 @@ export const teksterEn = {
     korrigeringKvittering: 'The changes to the employment status form have been submitted.',
     korrigeringIngenEndringer: 'You have not made any changes to this employment status form. ',
     korrigeringIngenEndringerTilbake: 'Return to edit employment status form',
+
+    juleferieInfo:
+        'If your programme is closed due to the Christmas holidays, you must report “participated” for the days you were scheduled to attend the programme. 🎄🎅🤶',
 } as const satisfies TeksterBaseRecord;
 
 type TeksterBaseRecord = Record<string, string | string[] | TekstResolver>;

--- a/src/tekster/nb.ts
+++ b/src/tekster/nb.ts
@@ -7,7 +7,6 @@ export const teksterNb = {
     startUtfylling: 'Start utfylling',
     forrige: 'Forrige steg',
     lagre: 'Lagre',
-    slett: 'Slett',
     nullstill: 'Nullstill',
     avbryt: 'Avbryt',
     avbrytEndring: 'Avbryt endring',
@@ -67,13 +66,10 @@ export const teksterNb = {
         `${fraOgMed} til ${tilOgMed}`,
 
     deltattTittel: 'Oppmøte',
-    deltattHjelpTittel: 'Slik fyller du ut meldekortet',
     deltattHjelpIngress:
         'Kryss av for de dagene du har deltatt på tiltaket som avtalt. Kryss også av for «deltok» hvis dagen er en offentlig fridag og du ikke får deltatt fordi tiltaket er stengt.',
     deltattUkeHjelp: 'Kryss av for de dagene du deltok på tiltaket.',
     deltattDagPrefix: 'Deltok: ',
-    fraværHjelpLesMer:
-        'Du må informere oss dersom du har vært syk eller hatt annet fravær i perioden du var satt opp på tiltak.',
     fraværStegFraværSpørsmål:
         'Har du vært syk eller hatt annet fravær noen av dagene du skulle vært på tiltaket?',
     fraværHarHattFraværSvarJa: 'Ja, jeg har vært syk eller hatt annet fravær',
@@ -245,6 +241,9 @@ export const teksterNb = {
     korrigeringKvittering: 'Endringer på meldekortet er sendt inn.',
     korrigeringIngenEndringer: 'Du har ikke gjort noen endringer på dette meldekortet. ',
     korrigeringIngenEndringerTilbake: 'Gå tilbake til korrigering av meldekortet',
+
+    juleferieInfo:
+        'Dersom tiltaket ditt er stengt på grunn av juleferie skal du melde «deltok» på dagene du skulle vært i tiltak. 🎄🎅🤶',
 } as const satisfies TeksterBaseRecord;
 
 type TeksterBaseRecord = Record<string, string | string[] | TekstResolver>;


### PR DESCRIPTION
Har oversatt resten av tekstene. Har også endret slik at alle sider fungerer med /en-endelse, og at interne linker beholder brukers locale ved navigering. 

https://trello.com/c/bPgyn0IK/1881-engelsk-tekst-p%C3%A5-startsiden-n%C3%A5r-ingen-meldekort-er-klare-til-innsending