### PR TITLE
1839 utbetalingsinfo for korrigert-kvittering

### DIFF
--- a/src/components/korrigerMeldekort/KorrigerMeldekortKvittering.tsx
+++ b/src/components/korrigerMeldekort/KorrigerMeldekortKvittering.tsx
@@ -9,6 +9,7 @@ import { formatterDato } from '@utils/datetime';
 
 import { useSpråk } from '@context/språk/useSpråk.ts';
 import React from 'react';
+import { EksternLenke } from '@components/lenke/EksternLenke.tsx';
 
 const KorrigerMeldekortKvittering = (props: { originaleMeldekort: Meldekort }) => {
     const { valgtSpråk, getTekstForSpråk } = useSpråk();
@@ -51,6 +52,17 @@ const KorrigerMeldekortKvittering = (props: { originaleMeldekort: Meldekort }) =
             <VStack gap="space-8">
                 <Alert variant="success">
                     <Tekst id={'korrigeringKvittering'} />
+                    <br />
+                    <br />
+                    <Tekst id={'korrigeringKvitteringMeldingSaksbehandler'} />
+                    <EksternLenke href={'https://www.nav.no/minside'}>
+                        {getTekstForSpråk({ id: 'korrigeringKvitteringForsideLenke' })}
+                    </EksternLenke>
+                    <Tekst id={'korrigeringKvitteringUtbetaling'} />
+                    <EksternLenke href={'https://www.nav.no/minside/utbetalinger'}>
+                        {getTekstForSpråk({ id: 'korrigeringKvitteringUtbetalingerLenke' })}
+                    </EksternLenke>
+                    {'.'}
                 </Alert>
                 <InternLenke path={getPath(siteRoutePaths.forside)} locale={valgtSpråk}>
                     <Tekst id={'kvitteringTilbake'} />

--- a/src/tekster/en.ts
+++ b/src/tekster/en.ts
@@ -242,7 +242,13 @@ export const teksterEn = {
     korrigeringUtfyllingFeilIngenEndring: 'No changes have been registered.',
     korrigeringIkkeSendt: 'The employment status form has not been submitted.',
     korrigeringOppsummering: 'Summary of edited employment status form',
-    korrigeringKvittering: 'The changes to the employment status form have been submitted.',
+    korrigeringKvittering:
+        'You have submitted the changes to your employment status form. The changes will be processed manually by a caseworker, and the processing may take a few days. ',
+    korrigeringKvitteringMeldingSaksbehandler:
+        'You will either receive a message from the caseworker at ',
+    korrigeringKvitteringForsideLenke: 'nav.no/minside',
+    korrigeringKvitteringUtbetaling: ', or you can check any payments at ',
+    korrigeringKvitteringUtbetalingerLenke: 'nav.no/minside/utbetalinger',
     korrigeringIngenEndringer: 'You have not made any changes to this employment status form. ',
     korrigeringIngenEndringerTilbake: 'Return to edit employment status form',
 

--- a/src/tekster/nb.ts
+++ b/src/tekster/nb.ts
@@ -238,7 +238,12 @@ export const teksterNb = {
     korrigeringUtfyllingFeilIngenEndring: 'Ingen endringer er registrert.',
     korrigeringIkkeSendt: 'Meldekortet er ikke sendt inn.',
     korrigeringOppsummering: 'Oppsummering av endret meldekort',
-    korrigeringKvittering: 'Endringer på meldekortet er sendt inn.',
+    korrigeringKvittering:
+        'Du har sendt inn endringene på meldekortet. Endringene behandles manuelt av en saksbehandler, og behandlingen kan ta noen dager. ',
+    korrigeringKvitteringMeldingSaksbehandler: 'Du vil enten få melding fra saksbehandleren på ',
+    korrigeringKvitteringForsideLenke: 'nav.no/minside',
+    korrigeringKvitteringUtbetaling: ' eller se eventuell utbetaling via ',
+    korrigeringKvitteringUtbetalingerLenke: 'nav.no/minside/utbetalinger',
     korrigeringIngenEndringer: 'Du har ikke gjort noen endringer på dette meldekortet. ',
     korrigeringIngenEndringerTilbake: 'Gå tilbake til korrigering av meldekortet',
 

--- a/tests/korrigering-meldekort.test.ts
+++ b/tests/korrigering-meldekort.test.ts
@@ -131,7 +131,7 @@ test('kan korrigere meldekort', async ({ page }) => {
     // Verifiserer at vi kommer til bekreftelse
     await page.waitForTimeout(1000); //her skjer det noe rare timing greier når man kjører fra terminalen.
     expect(page.url()).toContain('/12345/korrigering/kvittering');
-    expect(page.getByText('Endringer på meldekortet er sendt inn.')).toBeVisible();
+    expect(page.getByText('Du har sendt inn endringene på meldekortet.')).toBeVisible();
 });
 
 test.describe('kan avbryte korrigering av et meldekort', () => {
@@ -221,7 +221,7 @@ test('kan ikke sende inn meldekort uten å bekrefte', async ({ page }) => {
     // Verifiserer at vi kommer til bekreftelse
     await page.waitForTimeout(1000); //her skjer det noe rare timing greier når man kjører fra terminalen.
     expect(page.url()).toContain('/12345/korrigering/kvittering');
-    await expect(page.getByText('Endringer på meldekortet er sendt inn.')).toBeVisible();
+    await expect(page.getByText('Du har sendt inn endringene på meldekortet.')).toBeVisible();
 });
 
 test('forrige steg på oppsummering tar deg tilbake til korrigering med den korrigerte dataen', async ({


### PR DESCRIPTION
https://trello.com/c/UmQGOtRw/1839-endre-kvitteringssiden-for-korrigerte-meldekort-til-%C3%A5-informere-om-utbetalingstid